### PR TITLE
STM8 registers

### DIFF
--- a/llvm/lib/Target/STM8/STM8RegisterInfo.cpp
+++ b/llvm/lib/Target/STM8/STM8RegisterInfo.cpp
@@ -27,4 +27,49 @@
 
 namespace llvm {
 
+/// Initialize register info
+/// as there's no return address register, we Initialize
+/// that with 0
+STM8RegisterInfo::STM8RegisterInfo() : STM8GenRegisterInfo(0) {}
+
+const MCPhysReg *
+STM8RegisterInfo::getCalleeSavedRegs(const MachineFunction *MF) const {
+  // there are no callee saved regs, everything is caller saved
+  static const MCPhysReg EmptySavedRegs[] = {0};
+  return EmptySavedRegs;
+}
+
+BitVector STM8RegisterInfo::getReservedRegs(const MachineFunction &MF) const {
+  BitVector Reserved(getNumRegs());
+
+  Reserved.set(STM8::R_PC);
+  Reserved.set(STM8::R_PCE);
+  Reserved.set(STM8::R_PCH);
+  Reserved.set(STM8::R_PCL);
+  Reserved.set(STM8::R_PCHL);
+
+  Reserved.set(STM8::R_SP);
+
+  return Reserved;
+}
+
+const TargetRegisterClass *
+STM8RegisterInfo::getPointerRegClass(const MachineFunction &MF,
+                                     unsigned Kind) const {
+  // TODO: extend to actually support different memory models, so we should look
+  // at machine function
+  return &STM8::GPRPCERegClass;
+}
+
+bool STM8RegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator MI,
+                                           int SPAdj, unsigned FIOperandNum,
+                                           RegScavenger *RS) const {
+  // TODO: I've no idea yet what this does - smth. smth stack I think
+  return false;
+}
+
+Register STM8RegisterInfo::getFrameRegister(const MachineFunction &MF) const {
+  return STM8::R_SP;
+}
+
 } // end of namespace llvm

--- a/llvm/lib/Target/STM8/STM8RegisterInfo.cpp
+++ b/llvm/lib/Target/STM8/STM8RegisterInfo.cpp
@@ -42,12 +42,6 @@ STM8RegisterInfo::getCalleeSavedRegs(const MachineFunction *MF) const {
 BitVector STM8RegisterInfo::getReservedRegs(const MachineFunction &MF) const {
   BitVector Reserved(getNumRegs());
 
-  Reserved.set(STM8::R_PC);
-  Reserved.set(STM8::R_PCE);
-  Reserved.set(STM8::R_PCH);
-  Reserved.set(STM8::R_PCL);
-  Reserved.set(STM8::R_PCHL);
-
   Reserved.set(STM8::R_SP);
 
   return Reserved;
@@ -56,9 +50,9 @@ BitVector STM8RegisterInfo::getReservedRegs(const MachineFunction &MF) const {
 const TargetRegisterClass *
 STM8RegisterInfo::getPointerRegClass(const MachineFunction &MF,
                                      unsigned Kind) const {
-  // TODO: extend to actually support different memory models, so we should look
-  // at machine function
-  return &STM8::GPRPCERegClass;
+  // These are all registers that are used as a pointer (not exclusively)
+  // e.g. JP (X) or JP (Y)
+  return &STM8::GPR16RegClass;
 }
 
 bool STM8RegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator MI,

--- a/llvm/lib/Target/STM8/STM8RegisterInfo.h
+++ b/llvm/lib/Target/STM8/STM8RegisterInfo.h
@@ -24,6 +24,21 @@ namespace llvm {
 
 /// Utilities relating to STM8 registers.
 class STM8RegisterInfo : public STM8GenRegisterInfo {
+public:
+  STM8RegisterInfo();
+
+  const MCPhysReg *getCalleeSavedRegs(const MachineFunction *MF) const override;
+
+  BitVector getReservedRegs(const MachineFunction &MF) const override;
+  const TargetRegisterClass *
+  getPointerRegClass(const MachineFunction &MF,
+                     unsigned Kind = 0) const override;
+
+  bool eliminateFrameIndex(MachineBasicBlock::iterator MI, int SPAdj,
+                           unsigned FIOperandNum,
+                           RegScavenger *RS = nullptr) const override;
+
+  Register getFrameRegister(const MachineFunction &MF) const override;
 };
 
 } // end namespace llvm

--- a/llvm/lib/Target/STM8/STM8RegisterInfo.td
+++ b/llvm/lib/Target/STM8/STM8RegisterInfo.td
@@ -42,24 +42,12 @@ def R_YL : STM8Reg<3, "YL">, DwarfRegNum<[3]>;      // lower byte of Y
 def R_YH : STM8Reg<4, "YH">, DwarfRegNum<[4]>;      // higher byte of Y
 def R_C : STM8Reg<5, "C">, DwarfRegNum<[5]>;        // status register
 
-def R_PCE : STM8Reg<6, "PCE">, DwarfRegNum<[-1]>;   // extended byte of PC[24:16]
-def R_PCH : STM8Reg<7, "PCH">, DwarfRegNum<[-1]>;   // higher byte of PC[16:8]
-def R_PCL : STM8Reg<8, "PCL">, DwarfRegNum<[-1]>;   // lower byte of PC [8:0]
-
 // 16bit (sub)registers
 def R_SP : STM8Reg<11, "SP">, DwarfRegNum<[8]>;     // stack pointer
 
 let SubRegIndices = [sub_lo, sub_hi], CoveredBySubRegs = 1 in {
   def R_X : STM8Reg<9, "X", [R_XL, R_XH]>, DwarfRegNum<[6]>;   // X index
   def R_Y : STM8Reg<10, "Y", [R_YL, R_YH]>, DwarfRegNum<[7]>;  // Y index
-
-  // TODO: is it needed?
-  def R_PCHL : STM8Reg<12, "PCH:PCL", [R_PCL, R_PCH]>, DwarfRegNum<[-1]>;  // compilation targt register
-}
-
-// 24bit registers
-let SubRegIndices = [sub_lo, sub_hi, sub_ex], CoveredBySubRegs = 0 in {
-  def R_PC : STM8Reg<13, "PC", [R_PCL, R_PCH, R_PCE]>, DwarfRegNum<[9]>;  // the PC
 }
 
 //===----------------------------------------------------------------------===//
@@ -72,16 +60,12 @@ def GPR8 : RegisterClass<"STM8", [i8], 8, (
   add R_A,
   // index registers
   R_XL, R_XH, R_YL, R_YH,
-  // program counter
-  R_PCL, R_PCH, R_PCE
 )>;
 
 // main 16-bit register class (TODO: is this sensible?)
 def GPR16 : RegisterClass<"STM8", [i16], 8, (
   // index register
   add R_X, R_Y,
-  // lower pc half
-  R_PCHL
 )>;
 
 // accumulator register class
@@ -94,10 +78,6 @@ def GPRX : RegisterClass<"STM8", [i16], 8, (add R_X)>;   // long
 // y index register class
 def GPRYS : RegisterClass<"STM8", [i8], 8, (add R_YL)>;  // short
 def GPRY : RegisterClass<"STM8", [i16], 8, (add R_Y)>;   // long
-
-// program counter
-def GPRPCL : RegisterClass<"STM8", [i16], 8, (add R_PCHL)>; // long
-def GPRPCE : RegisterClass<"STM8", [i32], 8, (add R_PC)>;   // extended
 
 // Register class used for the stack read pseudo instruction.
 def GPRSP : RegisterClass<"STM8", [i16], 8, (add R_SP)>;


### PR DESCRIPTION
> [!NOTE]
> I know that there's a branch called stm8-register and this one is called stm8-registers. When we created the stm8-register branch, I don't think we very ready to actually separate every feature in their own branch as the fundamental structure was missing and we did not knew enough. But that has changed, so I'll try again

 This PR tracks what the title says. This is for implementing / feature complete the `STM8RegisterInfo` class and the accompanying `STM8RegisterInfo.td` file.

The current status is that there are a few TODOs in these two files that still need to be looked at / two functions that need to be fully implemented. I'll track the TODOs here too.

## TODOs
- [ ] are the chosen register classes sensible?
- [ ] is `R_PCHL` necessary?
- [ ] `STM8RegisterInfo::getPointerRegClass`
- [ ] `STM8RegisterInfo::eliminateFrameIndex`

### are the chosen reg classes sensible?
This is a TODO mostly to remind us that this can be easily modified if necessary. The current register classes chosen mostly orient themselves according how the AVR backend does it, but it could also mean that it doesn't fit for STM8. 

We will probably discover problems here only over time as we implement other aspects of the backend - so I expect this to be open for a long time.


### is `R_PCHL` necessary?
This is a register that joins the PC High and Low register into a single 16bit reg. The description from the previously TODO also applies here. We need to figure this out over a longer time period.

### `STM8RegisterInfo::getPointerRegClass`
Every backend must override this method. For other targets this might be quite easy, but several comments in the LLVM codebase suggests that this can be instruction depended. In some cases that could mean that this depends on the addressing mode we're operating in. Currently just the PC reg class was chosen.

### `STM8RegisterInfo::eliminateFrameIndex`
Yeah no clue for now. I haven't rly took the time to look into it yet